### PR TITLE
Issue #13: A MrzParserException is thrown when the dates in the MRZ are invalid (e.g 1999 September 35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /build
-app.iml
 build.gradle
 proguard-rules.pro
 src/main/AndroidManifest.xml
 src/main/res/
+/target
+/.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.innovatrics.mrz</groupId>
     <artifactId>mrz-java</artifactId>
     <packaging>jar</packaging>
-    <version>0.5</version>
+    <version>0.6-SNAPSHOT</version>
     <name>MRZ Java Parser</name>
     <url>https://github.com/ZsBT/mrz-java</url>
     <inceptionYear>2011</inceptionYear>
@@ -63,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
-<!-- Fixes compilation issue on Java 8 -->
-      <configuration>
-        <additionalparam>-Xdoclint:none</additionalparam>
-      </configuration>
+                <!-- Fixes compilation issue on Java 8 -->
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/innovatrics/mrz/MrzParser.java
+++ b/src/main/java/com/innovatrics/mrz/MrzParser.java
@@ -21,11 +21,12 @@ package com.innovatrics.mrz;
 import com.innovatrics.mrz.types.MrzDate;
 import com.innovatrics.mrz.types.MrzFormat;
 import com.innovatrics.mrz.types.MrzSex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * Parses the MRZ records.
@@ -165,7 +166,7 @@ public class MrzParser {
         return invalidCheckdigit==null;
     }
 
-    static Logger log ;
+    private static Logger log = LoggerFactory.getLogger(MrzParser.class);
 
     /**
      * Parses MRZ date.
@@ -182,17 +183,17 @@ public class MrzParser {
             r = new MrzRange(range.column, range.column + 2, range.row);
             final int year = Integer.parseInt(rawValue(r));
             if (year < 0 || year > 99) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid year value " + year + ": must be 0..99", mrz, r, format);
+                log.debug("Invalid year value " + year + ": must be 0..99");
             }
             r = new MrzRange(range.column + 2, range.column + 4, range.row);
             final int month = Integer.parseInt(rawValue(r));
             if (month < 1 || month > 12) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid month value " + month + ": must be 1..12", mrz, r, format);
+                log.debug("Invalid month value " + month + ": must be 1..12");
             }
             r = new MrzRange(range.column + 4, range.column + 6, range.row);
             final int day = Integer.parseInt(rawValue(r));
             if (day < 1 || day > 31) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid day value " + day + ": must be 1..31", mrz, r, format);
+                log.debug("Invalid day value " + day + ": must be 1..31");
             }
             return new MrzDate(year, month, day);
         } catch (NumberFormatException ex) {

--- a/src/main/java/com/innovatrics/mrz/types/MrzDate.java
+++ b/src/main/java/com/innovatrics/mrz/types/MrzDate.java
@@ -121,6 +121,10 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
         return Integer.valueOf(year * 10000 + month * 100 + day).compareTo(o.year * 10000 + o.month * 100 + o.day);
     }
 
+    /**
+     * Returns the date validity
+     * @return Returns a boolean true if the parsed date is valid, false otherwise
+     */
     public boolean isValidDate() {
         return isValidDate;
     }

--- a/src/main/java/com/innovatrics/mrz/types/MrzDate.java
+++ b/src/main/java/com/innovatrics/mrz/types/MrzDate.java
@@ -18,7 +18,11 @@
  */
 package com.innovatrics.mrz.types;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
+
 
 /**
  * Holds a MRZ date type.
@@ -26,6 +30,9 @@ import java.io.Serializable;
  */
 public class MrzDate implements Serializable, Comparable<MrzDate> {
     private static final long serialVersionUID = 1L;
+
+    private static Logger log = LoggerFactory.getLogger(MrzDate.class);
+
 
     /**
      * Year, 00-99.
@@ -42,11 +49,16 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
      */
     public final int day;
 
+    /**
+     * Is the date valid or not
+     */
+    private final boolean isValidDate;
+
     public MrzDate(int year, int month, int day) {
         this.year = year;
         this.month = month;
         this.day = day;
-        check();
+        isValidDate = check();
     }
 
     @Override
@@ -58,16 +70,21 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
         return String.format("%02d%02d%02d", year, month, day);
     }
 
-    private void check() {
+    private boolean check() {
         if (year < 0 || year > 99) {
-            throw new IllegalArgumentException("Parameter year: invalid value " + year + ": must be 0..99");
+            log.debug("Parameter year: invalid value " + year + ": must be 0..99");
+            return false;
         }
         if (month < 1 || month > 12) {
-            throw new IllegalArgumentException("Parameter month: invalid value " + month + ": must be 1..12");
+            log.debug("Parameter month: invalid value " + month + ": must be 1..12");
+            return false;
         }
         if (day < 1 || day > 31) {
-            throw new IllegalArgumentException("Parameter day: invalid value " + day + ": must be 1..31");
+            log.debug("Parameter day: invalid value " + day + ": must be 1..31");
+            return false;
         }
+
+        return true;
     }
 
     @Override
@@ -102,5 +119,9 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
 
     public int compareTo(MrzDate o) {
         return Integer.valueOf(year * 10000 + month * 100 + day).compareTo(o.year * 10000 + o.month * 100 + o.day);
+    }
+
+    public boolean isValidDate() {
+        return isValidDate;
     }
 }

--- a/src/test/java/com/innovatrics/mrz/MrzParserTest.java
+++ b/src/test/java/com/innovatrics/mrz/MrzParserTest.java
@@ -53,7 +53,6 @@ public class MrzParserTest {
         assertEquals( true, MrzParser.parse(GermanPassport).validExpirationDate );
         assertEquals( true, MrzParser.parse(GermanPassport).validDocumentNumber );
         assertEquals( false, MrzParser.parse(GermanPassport).validComposite ); // yes, this specimen has intentationally wrong check digit
-
     }
 
     @Test
@@ -85,5 +84,27 @@ public class MrzParserTest {
         assertEquals("NILAVADHANANANDA<<CHAYAPA<DEJ<K", MrzParser.nameToMrz("Nilavadhanananda", "Chayapa Dejthamrong Krasuang", 31));
         assertEquals("NILAVADHANANANDA<<ARNPOL<PETC<C", MrzParser.nameToMrz("NILAVADHANANANDA", "ARNPOL PETCH CHARONGUANG", 31));
         assertEquals("BENNELONG<WOOLOOMOOLOO<W<W<<D<P", MrzParser.nameToMrz("BENNELONG WOOLOOMOOLOO WARRANDYTE WARNAMBOOL", "DINGO POTOROO", 31));
+    }
+
+    @Test
+    public void testValidDates() {
+        String validBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809317F2007162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(validBirthDateMrz);
+        assertEquals(true, record.dateOfBirth.isValidDate());
+        assertEquals(true, record.expirationDate.isValidDate());
+    }
+
+    @Test
+    public void testInvalidBirthDate() {
+        String invalidBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809417F2007162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(invalidBirthDateMrz);
+        assertEquals(false, record.dateOfBirth.isValidDate());
+    }
+
+    @Test
+    public void testInvalidExpiryDate() {
+        String invalidExpiryDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809117F2007462<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(invalidExpiryDateMrz);
+        assertEquals(false, record.expirationDate.isValidDate());
     }
 }

--- a/src/test/java/com/innovatrics/mrz/MrzParserTest.java
+++ b/src/test/java/com/innovatrics/mrz/MrzParserTest.java
@@ -95,14 +95,14 @@ public class MrzParserTest {
     }
 
     @Test
-    public void testInvalidBirthDate() {
+    public void testMrzInvalidBirthDate() {
         String invalidBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809417F2007162<<<<<<<<<<<<<<08";
         MrzRecord record = MrzParser.parse(invalidBirthDateMrz);
         assertEquals(false, record.dateOfBirth.isValidDate());
     }
 
     @Test
-    public void testInvalidExpiryDate() {
+    public void testMrzInvalidExpiryDate() {
         String invalidExpiryDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809117F2007462<<<<<<<<<<<<<<08";
         MrzRecord record = MrzParser.parse(invalidExpiryDateMrz);
         assertEquals(false, record.expirationDate.isValidDate());

--- a/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
+++ b/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
@@ -57,6 +57,7 @@ public class MrzDateTest {
         assertEquals("081201", new MrzDate(8, 12, 1).toMrz());
     }
 
+    @Test
     public void testInvalidDate() {
         MrzDate date = new MrzDate(88, 9, 41);
         assertEquals(88, date.year);
@@ -65,6 +66,7 @@ public class MrzDateTest {
         assertEquals(false, date.isValidDate());
     }
 
+    @Test
     public void testValidDate() {
         MrzDate date = new MrzDate(88, 9, 30);
         assertEquals(88, date.year);

--- a/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
+++ b/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
@@ -56,4 +56,20 @@ public class MrzDateTest {
         assertEquals("550431", new MrzDate(55, 4, 31).toMrz());
         assertEquals("081201", new MrzDate(8, 12, 1).toMrz());
     }
+
+    public void testInvalidDate() {
+        MrzDate date = new MrzDate(88, 9, 41);
+        assertEquals(88, date.year);
+        assertEquals(9, date.month);
+        assertEquals(41, date.day);
+        assertEquals(false, date.isValidDate());
+    }
+
+    public void testValidDate() {
+        MrzDate date = new MrzDate(88, 9, 30);
+        assertEquals(88, date.year);
+        assertEquals(9, date.month);
+        assertEquals(30, date.day);
+        assertEquals(true, date.isValidDate());
+    }
 }


### PR DESCRIPTION
- No MrzParserException thrown when the dates in the MRZ are invalid.
- New boolean isValidDate in the MrzDate that indicates the validity of the date.
- Documentation updated (MrzDate.isValidDate())
- I noticed that you released a version 0.5 of the library. I temporarily changed the version number to 0.6-SNAPSHOT, I let you decide what it will be.