### PR TITLE
merge achievements from development to master. (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /build
-app.iml
 build.gradle
 proguard-rules.pro
 src/main/AndroidManifest.xml
 src/main/res/
+/target
+/.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Machine-Readable Zone (MRZ, see http://en.wikipedia.org/wiki/Machine-readable_passport ) parser for Java, as defined by ICAO: http://www.icao.int/
 
+## Branches
+
+Branch "master" is for hotfixes only. For enhancements and minor bugfixes, please use branch "development".
 
 ## Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.innovatrics.mrz</groupId>
     <artifactId>mrz-java</artifactId>
     <packaging>jar</packaging>
-    <version>0.5</version>
+    <version>0.6-SNAPSHOT</version>
     <name>MRZ Java Parser</name>
     <url>https://github.com/ZsBT/mrz-java</url>
     <inceptionYear>2011</inceptionYear>
@@ -63,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -82,10 +82,10 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
-<!-- Fixes compilation issue on Java 8 -->
-      <configuration>
-        <additionalparam>-Xdoclint:none</additionalparam>
-      </configuration>
+                <!-- Fixes compilation issue on Java 8 -->
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/innovatrics/mrz/MrzParser.java
+++ b/src/main/java/com/innovatrics/mrz/MrzParser.java
@@ -21,11 +21,12 @@ package com.innovatrics.mrz;
 import com.innovatrics.mrz.types.MrzDate;
 import com.innovatrics.mrz.types.MrzFormat;
 import com.innovatrics.mrz.types.MrzSex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * Parses the MRZ records.
@@ -165,7 +166,7 @@ public class MrzParser {
         return invalidCheckdigit==null;
     }
 
-    static Logger log ;
+    private static Logger log = LoggerFactory.getLogger(MrzParser.class);
 
     /**
      * Parses MRZ date.
@@ -177,27 +178,42 @@ public class MrzParser {
         if (range.length() != 6) {
             throw new IllegalArgumentException("Parameter range: invalid value " + range + ": must be 6 characters long");
         }
-        MrzRange r = null;
+        MrzRange r;
+        r = new MrzRange(range.column, range.column + 2, range.row);
+        int year;
         try {
-            r = new MrzRange(range.column, range.column + 2, range.row);
-            final int year = Integer.parseInt(rawValue(r));
-            if (year < 0 || year > 99) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid year value " + year + ": must be 0..99", mrz, r, format);
-            }
-            r = new MrzRange(range.column + 2, range.column + 4, range.row);
-            final int month = Integer.parseInt(rawValue(r));
-            if (month < 1 || month > 12) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid month value " + month + ": must be 1..12", mrz, r, format);
-            }
-            r = new MrzRange(range.column + 4, range.column + 6, range.row);
-            final int day = Integer.parseInt(rawValue(r));
-            if (day < 1 || day > 31) {
-                throw new MrzParseException("Failed to parse MRZ date: invalid day value " + day + ": must be 1..31", mrz, r, format);
-            }
-            return new MrzDate(year, month, day);
+            year = Integer.parseInt(rawValue(r));
         } catch (NumberFormatException ex) {
-            throw new MrzParseException("Failed to parse MRZ date " + rawValue(range) + ": " + ex, mrz, r, format);
+            year = -1;
+            log.debug("Failed to parse MRZ date year " + rawValue(range) + ": " + ex, mrz, r);
         }
+        if (year < 0 || year > 99) {
+            log.debug("Invalid year value " + year + ": must be 0..99");
+        }
+        r = new MrzRange(range.column + 2, range.column + 4, range.row);
+        int month;
+        try {
+            month = Integer.parseInt(rawValue(r));
+        } catch (NumberFormatException ex) {
+            month = -1;
+            log.debug("Failed to parse MRZ date month " + rawValue(range) + ": " + ex, mrz, r);
+        }
+        if (month < 1 || month > 12) {
+            log.debug("Invalid month value " + month + ": must be 1..12");
+        }
+        r = new MrzRange(range.column + 4, range.column + 6, range.row);
+        int day;
+        try {
+            day = Integer.parseInt(rawValue(r));
+        } catch (NumberFormatException ex) {
+            day = -1;
+            log.debug("Failed to parse MRZ date month " + rawValue(range) + ": " + ex, mrz, r);
+        }
+        if (day < 1 || day > 31) {
+            log.debug("Invalid day value " + day + ": must be 1..31");
+        }
+        return new MrzDate(year, month, day, rawValue(range));
+
     }
 
     /**

--- a/src/main/java/com/innovatrics/mrz/records/FrenchIdCard.java
+++ b/src/main/java/com/innovatrics/mrz/records/FrenchIdCard.java
@@ -63,7 +63,7 @@ public class FrenchIdCard extends MrzRecord {
         documentNumber = p.parseString(new MrzRange(0, 12, 1));
         validDocumentNumber = p.checkDigit(12, 1, new MrzRange(0, 12, 1), "document number");
         dateOfBirth = p.parseDate(new MrzRange(27, 33, 1));
-        validDateOfBirth = p.checkDigit(33, 1, new MrzRange(27, 33, 1), "date of birth");
+        validDateOfBirth = p.checkDigit(33, 1, new MrzRange(27, 33, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = p.parseSex(34, 1);
         final String finalChecksum = mrz.toString().replace("\n","").substring(0, 36 + 35);
         validComposite = p.checkDigit(35, 1, finalChecksum, "final checksum");

--- a/src/main/java/com/innovatrics/mrz/records/MRP.java
+++ b/src/main/java/com/innovatrics/mrz/records/MRP.java
@@ -49,10 +49,10 @@ public class MRP extends MrzRecord {
         validDocumentNumber = parser.checkDigit(9, 1, new MrzRange(0, 9, 1), "passport number");
         nationality = parser.parseString(new MrzRange(10, 13, 1));
         dateOfBirth = parser.parseDate(new MrzRange(13, 19, 1));
-        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth");
+        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = parser.parseSex(20, 1);
         expirationDate = parser.parseDate(new MrzRange(21, 27, 1));
-        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date");
+        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date") && expirationDate.isDateValid();
         personalNumber = parser.parseString(new MrzRange(28, 42, 1));
         validPersonalNumber = parser.checkDigit(42, 1, new MrzRange(28, 42, 1), "personal number");
         validComposite = parser.checkDigit(43, 1, parser.rawValue(new MrzRange(0, 10, 1), new MrzRange(13, 20, 1), new MrzRange(21, 43, 1)), "mrz");

--- a/src/main/java/com/innovatrics/mrz/records/MrtdTd1.java
+++ b/src/main/java/com/innovatrics/mrz/records/MrtdTd1.java
@@ -53,10 +53,10 @@ public class MrtdTd1 extends MrzRecord {
         validDocumentNumber = p.checkDigit(14, 0, new MrzRange(5, 14, 0), "document number");
         optional = p.parseString(new MrzRange(15, 30, 0));
         dateOfBirth = p.parseDate(new MrzRange(0, 6, 1));
-        validDateOfBirth = p.checkDigit(6, 1, new MrzRange(0, 6, 1), "date of birth");
+        validDateOfBirth = p.checkDigit(6, 1, new MrzRange(0, 6, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = p.parseSex(7, 1);
         expirationDate = p.parseDate(new MrzRange(8, 14, 1));
-        validExpirationDate = p.checkDigit(14, 1, new MrzRange(8, 14, 1), "expiration date");
+        validExpirationDate = p.checkDigit(14, 1, new MrzRange(8, 14, 1), "expiration date") && expirationDate.isDateValid();
         nationality = p.parseString(new MrzRange(15, 18, 1));
         optional2 = p.parseString(new MrzRange(18, 29, 1));
         validComposite = p.checkDigit(29, 1, p.rawValue(new MrzRange(5, 30, 0), new MrzRange(0, 7, 1), new MrzRange(8, 15, 1), new MrzRange(18, 29, 1)), "mrz");

--- a/src/main/java/com/innovatrics/mrz/records/MrtdTd2.java
+++ b/src/main/java/com/innovatrics/mrz/records/MrtdTd2.java
@@ -50,10 +50,10 @@ public class MrtdTd2 extends MrzRecord {
         validDocumentNumber = p.checkDigit(9, 1, new MrzRange(0, 9, 1), "document number");
         nationality = p.parseString(new MrzRange(10, 13, 1));
         dateOfBirth = p.parseDate(new MrzRange(13, 19, 1));
-        validDateOfBirth = p.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth");
+        validDateOfBirth = p.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = p.parseSex(20, 1);
         expirationDate = p.parseDate(new MrzRange(21, 27, 1));
-        validExpirationDate = p.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date");
+        validExpirationDate = p.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date") && expirationDate.isDateValid();
         optional = p.parseString(new MrzRange(28, 35, 1));
         validComposite = p.checkDigit(35, 1, p.rawValue(new MrzRange(0, 10, 1), new MrzRange(13, 20, 1), new MrzRange(21, 35, 1)), "mrz");
     }

--- a/src/main/java/com/innovatrics/mrz/records/MrvA.java
+++ b/src/main/java/com/innovatrics/mrz/records/MrvA.java
@@ -52,10 +52,10 @@ public class MrvA extends MrzRecord {
         validDocumentNumber = parser.checkDigit(9, 1, new MrzRange(0, 9, 1), "passport number");
         nationality = parser.parseString(new MrzRange(10, 13, 1));
         dateOfBirth = parser.parseDate(new MrzRange(13, 19, 1));
-        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth");
+        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = parser.parseSex(20, 1);
         expirationDate = parser.parseDate(new MrzRange(21, 27, 1));
-        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date");
+        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date") && expirationDate.isDateValid();
         optional = parser.parseString(new MrzRange(28, 44, 1));
         // TODO validComposite missing? (final MRZ check digit)
     }

--- a/src/main/java/com/innovatrics/mrz/records/MrvB.java
+++ b/src/main/java/com/innovatrics/mrz/records/MrvB.java
@@ -52,10 +52,10 @@ public class MrvB extends MrzRecord {
         validDocumentNumber = parser.checkDigit(9, 1, new MrzRange(0, 9, 1), "passport number");
         nationality = parser.parseString(new MrzRange(10, 13, 1));
         dateOfBirth = parser.parseDate(new MrzRange(13, 19, 1));
-        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth");
+        validDateOfBirth = parser.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = parser.parseSex(20, 1);
         expirationDate = parser.parseDate(new MrzRange(21, 27, 1));
-        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date");
+        validExpirationDate = parser.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date") && expirationDate.isDateValid();
         optional = parser.parseString(new MrzRange(28, 36, 1));
         // TODO validComposite missing? (full MRZ line)
     }

--- a/src/main/java/com/innovatrics/mrz/records/SlovakId2_34.java
+++ b/src/main/java/com/innovatrics/mrz/records/SlovakId2_34.java
@@ -50,10 +50,10 @@ public class SlovakId2_34 extends MrzRecord {
         validDocumentNumber = p.checkDigit(9, 1, new MrzRange(0, 9, 1), "document number");
         nationality = p.parseString(new MrzRange(10, 13, 1));
         dateOfBirth = p.parseDate(new MrzRange(13, 19, 1));
-        validDateOfBirth = p.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth");
+        validDateOfBirth = p.checkDigit(19, 1, new MrzRange(13, 19, 1), "date of birth") && dateOfBirth.isDateValid();
         sex = p.parseSex(20, 1);
         expirationDate = p.parseDate(new MrzRange(21, 27, 1));
-        validExpirationDate = p.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date");
+        validExpirationDate = p.checkDigit(27, 1, new MrzRange(21, 27, 1), "expiration date") && expirationDate.isDateValid();
         optional = p.parseString(new MrzRange(28, 34, 1));
         // TODO validComposite missing? (final MRZ check digit)
     }

--- a/src/main/java/com/innovatrics/mrz/types/MrzDate.java
+++ b/src/main/java/com/innovatrics/mrz/types/MrzDate.java
@@ -18,7 +18,11 @@
  */
 package com.innovatrics.mrz.types;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
+
 
 /**
  * Holds a MRZ date type.
@@ -26,6 +30,9 @@ import java.io.Serializable;
  */
 public class MrzDate implements Serializable, Comparable<MrzDate> {
     private static final long serialVersionUID = 1L;
+
+    private static Logger log = LoggerFactory.getLogger(MrzDate.class);
+
 
     /**
      * Year, 00-99.
@@ -42,11 +49,27 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
      */
     public final int day;
 
+    private final String mrz;
+
+    /**
+     * Is the date valid or not
+     */
+    private final boolean isValidDate;
+
     public MrzDate(int year, int month, int day) {
         this.year = year;
         this.month = month;
         this.day = day;
-        check();
+        isValidDate = check();
+        this.mrz = null;
+    }
+
+    public MrzDate(int year, int month, int day, String raw) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        isValidDate = check();
+        this.mrz = raw;
     }
 
     @Override
@@ -55,19 +78,28 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
     }
 
     public String toMrz() {
-        return String.format("%02d%02d%02d", year, month, day);
+        if(mrz != null) {
+            return mrz;
+        } else {
+            return String.format("%02d%02d%02d", year, month, day);
+        }
     }
 
-    private void check() {
+    private boolean check() {
         if (year < 0 || year > 99) {
-            throw new IllegalArgumentException("Parameter year: invalid value " + year + ": must be 0..99");
+            log.debug("Parameter year: invalid value " + year + ": must be 0..99");
+            return false;
         }
         if (month < 1 || month > 12) {
-            throw new IllegalArgumentException("Parameter month: invalid value " + month + ": must be 1..12");
+            log.debug("Parameter month: invalid value " + month + ": must be 1..12");
+            return false;
         }
         if (day < 1 || day > 31) {
-            throw new IllegalArgumentException("Parameter day: invalid value " + day + ": must be 1..31");
+            log.debug("Parameter day: invalid value " + day + ": must be 1..31");
+            return false;
         }
+
+        return true;
     }
 
     @Override
@@ -102,5 +134,13 @@ public class MrzDate implements Serializable, Comparable<MrzDate> {
 
     public int compareTo(MrzDate o) {
         return Integer.valueOf(year * 10000 + month * 100 + day).compareTo(o.year * 10000 + o.month * 100 + o.day);
+    }
+
+    /**
+     * Returns the date validity
+     * @return Returns a boolean true if the parsed date is valid, false otherwise
+     */
+    public boolean isDateValid() {
+        return isValidDate;
     }
 }

--- a/src/test/java/com/innovatrics/mrz/MrzParserTest.java
+++ b/src/test/java/com/innovatrics/mrz/MrzParserTest.java
@@ -53,7 +53,6 @@ public class MrzParserTest {
         assertEquals( true, MrzParser.parse(GermanPassport).validExpirationDate );
         assertEquals( true, MrzParser.parse(GermanPassport).validDocumentNumber );
         assertEquals( false, MrzParser.parse(GermanPassport).validComposite ); // yes, this specimen has intentationally wrong check digit
-
     }
 
     @Test
@@ -85,5 +84,65 @@ public class MrzParserTest {
         assertEquals("NILAVADHANANANDA<<CHAYAPA<DEJ<K", MrzParser.nameToMrz("Nilavadhanananda", "Chayapa Dejthamrong Krasuang", 31));
         assertEquals("NILAVADHANANANDA<<ARNPOL<PETC<C", MrzParser.nameToMrz("NILAVADHANANANDA", "ARNPOL PETCH CHARONGUANG", 31));
         assertEquals("BENNELONG<WOOLOOMOOLOO<W<W<<D<P", MrzParser.nameToMrz("BENNELONG WOOLOOMOOLOO WARRANDYTE WARNAMBOOL", "DINGO POTOROO", 31));
+    }
+
+    @Test
+    public void testValidDates() {
+        String validBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809117F2007162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(validBirthDateMrz);
+        assertEquals(true, record.dateOfBirth.isDateValid());
+        assertEquals(true, record.expirationDate.isDateValid());
+        assertEquals(true, record.validDateOfBirth);
+        assertEquals(true, record.validExpirationDate);
+    }
+
+    @Test
+    public void testMrzInvalidBirthDate() {
+        String invalidBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809417F2007162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(invalidBirthDateMrz);
+        assertEquals(false, record.dateOfBirth.isDateValid());
+        assertEquals(false, record.validDateOfBirth);
+    }
+
+    @Test
+    public void testMrzInvalidExpiryDate() {
+        String invalidExpiryDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809117F2007462<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(invalidExpiryDateMrz);
+        assertEquals(false, record.expirationDate.isDateValid());
+        assertEquals(false, record.validExpirationDate);
+    }
+
+    @Test
+    public void testUnparseableDates() {
+        String unparseableDatesMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBRBB09117F2ZZ7162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(unparseableDatesMrz);
+        assertNotNull(record.dateOfBirth);
+        assertEquals(-1, record.dateOfBirth.year);
+        assertEquals(9, record.dateOfBirth.month);
+        assertEquals(11, record.dateOfBirth.day);
+        assertEquals(false, record.dateOfBirth.isDateValid());
+        assertEquals(false, record.validDateOfBirth);
+
+        assertNotNull(record.expirationDate);
+        assertEquals(-1, record.expirationDate.year);
+        assertEquals(-1, record.expirationDate.month);
+        assertEquals(16, record.expirationDate.day);
+        assertEquals(false, record.expirationDate.isDateValid());
+        assertEquals(false, record.validExpirationDate);
+    }
+
+    @Test
+    public void testRawDate() {
+        String validBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809117F2007162<<<<<<<<<<<<<<08";
+        MrzRecord record = MrzParser.parse(validBirthDateMrz);
+        assertEquals("880911", record.dateOfBirth.toMrz());
+
+        String invalidBirthDateMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBR8809417F2007162<<<<<<<<<<<<<<08";
+        record = MrzParser.parse(invalidBirthDateMrz);
+        assertEquals("880941", record.dateOfBirth.toMrz());
+
+        String unparseableDatesMrz = "P<GBRUK<SPECIMEN<<ANGELA<ZOE<<<<<<<<<<<<<<<<\n9250764733GBRBB09117F2007162<<<<<<<<<<<<<<08";
+        record = MrzParser.parse(unparseableDatesMrz);
+        assertEquals("BB0911", record.dateOfBirth.toMrz());
     }
 }

--- a/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
+++ b/src/test/java/com/innovatrics/mrz/types/MrzDateTest.java
@@ -55,5 +55,25 @@ public class MrzDateTest {
     public void testToMrz() {
         assertEquals("550431", new MrzDate(55, 4, 31).toMrz());
         assertEquals("081201", new MrzDate(8, 12, 1).toMrz());
+        assertEquals("880941", new MrzDate(88, 9, 41).toMrz());
+        assertEquals("BB1201", new MrzDate(-1, 12, 1, "BB1201").toMrz());
+    }
+
+    @Test
+    public void testInvalidDate() {
+        MrzDate date = new MrzDate(88, 9, 41);
+        assertEquals(88, date.year);
+        assertEquals(9, date.month);
+        assertEquals(41, date.day);
+        assertEquals(false, date.isDateValid());
+    }
+
+    @Test
+    public void testValidDate() {
+        MrzDate date = new MrzDate(88, 9, 30);
+        assertEquals(88, date.year);
+        assertEquals(9, date.month);
+        assertEquals(30, date.day);
+        assertEquals(true, date.isDateValid());
     }
 }


### PR DESCRIPTION
* Issue #13: A MrzParserException is thrown when the dates in the MRZ are invalid (e.g 1999 September 35) (#14)

* - No MrzParserException thrown when the dates in the MRZ are invalid.
- New boolean isValidDate in the MrzDate that indicates the validity of the date.

* - Documentation added for the isValidDate() function of the MrzDate class

* Unit tests fix

* JDK version downgraded to 1.7 for Android compatibility

* set validDateOfBirth and validExpirationDate booleans to false when date are invalid

* introducing development branch

* Error handling when unparseable dates (#17)

- No MrzParseException
- Unparseable year, month or day set to -1

* Raw value field in MrzDate (#19)

this will merely help an auto-correction in the future.